### PR TITLE
fix: [이용휘] accessToken 제거하지 않음

### DIFF
--- a/src/authentication/store/actions.ts
+++ b/src/authentication/store/actions.ts
@@ -72,7 +72,7 @@ const actions: AuthenticationActions = {
 
             console.log('userToken:', response.data.userToken)
 
-            localStorage.removeItem("accessToken")
+            // localStorage.removeItem("accessToken")
             localStorage.setItem("userToken", response.data.userToken)
             commit(REQUEST_IS_AUTHENTICATED_TO_DJANGO, true);
             return response.data;


### PR DESCRIPTION
accessToken을 제거하면 데이터 송수신이 잘 되지 않아서 일단은 제거하지 않는 방향으로 하겠습니다.